### PR TITLE
feat: Implement visual scraping with Playwright and Llava

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,28 @@
 # PEI Emergency Room Wait Time Tracker
 
-This project scrapes the emergency room wait times for hospitals on Prince Edward Island from the [official Health PEI website](https://www.princeedwardisland.ca/en/information/health-pei/emergency-department-wait-times). It runs continuously, saving the data every hour to a CSV file. This allows for building a historical record of wait times to analyze trends.
+This project scrapes the emergency room wait times for hospitals on Prince Edward Island. It uses a multimodal AI approach to visually extract data from the [official Health PEI website](https://www.princeedwardisland.ca/en/information/health-pei/emergency-department-wait-times). It runs continuously, saving the data every hour to a CSV file. This allows for building a historical record of wait times to analyze trends.
 
 ## Features
 
-- Scrapes wait times for all hospitals listed on the Health PEI page.
+- Uses Playwright to take screenshots of hospital wait time pages.
+- Leverages a local Llava model to extract wait time data from screenshots.
 - Saves data with a timestamp to `hospital_wait_times.csv`.
 - Runs automatically every hour to collect data continuously.
-- Cleans the scraped data for better readability.
 
 ## How to Use
 
-### 1. Setup
+### 1. Prerequisites
+
+This project requires a locally running instance of the Llava model. You can set this up using [Ollama](https://ollama.ai/).
+
+1.  **Install Ollama:** Follow the instructions on the Ollama website to install it on your system.
+2.  **Pull the Llava model:** Once Ollama is installed, pull the Llava model by running the following command in your terminal:
+    ```bash
+    ollama pull llava
+    ```
+3.  **Ensure the Ollama server is running:** The script connects to the Ollama API at `http://localhost:11434`. Make sure the Ollama application is running before you start the scraper.
+
+### 2. Setup
 
 First, you need to install the necessary Python dependencies. It's recommended to do this in a virtual environment.
 
@@ -22,9 +33,12 @@ source venv/bin/activate  # On Windows, use `venv\Scripts\activate`
 
 # Install the required packages
 pip install -r requirements.txt
+
+# Install Playwright browsers
+playwright install
 ```
 
-### 2. Running the Scraper
+### 3. Running the Scraper
 
 To start the scraper, simply run the `ertmain.py` script:
 
@@ -32,23 +46,29 @@ To start the scraper, simply run the `ertmain.py` script:
 python ertmain.py
 ```
 
-The script will then start running in your terminal. It will print status messages as it fetches new data.
+The script will then start running in your terminal. It will print status messages as it navigates to the hospital websites, takes screenshots, and analyzes them with Llava.
 
 ```
-Fetching new wait times...
-Successfully scraped 4 entries.
+Navigating to https://www.princeedwardisland.ca/en/feature/emergency-department-wait-times-queen-elizabeth-hospital-qeh...
+Screenshot saved to screenshot_0.png
+Analyzing screenshot_0.png with Llava...
 Data successfully saved to hospital_wait_times.csv
+...
 Waiting for 1 hour before next scrape...
 ```
 
 You can stop the scraper at any time by pressing `Ctrl+C` in the terminal.
 
-### 3. The Output
+### 4. The Output
 
 The scraped data is saved in a file named `hospital_wait_times.csv`. A new entry for each hospital is added every hour.
 
 The CSV file has the following columns:
 
 - **Timestamp**: The date and time when the data was scraped (e.g., `2023-10-27 14:30:00`).
-- **Hospital**: The name of the hospital.
-- **WaitTime**: The estimated emergency room wait time at the time of scraping.
+- **hospital_name**: The name of the hospital.
+- **patients_in_waiting_room**: The number of patients in the waiting room.
+- **urgent_patients**: The number of urgent patients.
+- **urgent_wait_time**: The estimated wait time for urgent patients.
+- **less_urgent_patients**: The number of less urgent patients.
+- **less_urgent_wait_time**: The estimated wait time for less urgent patients.

--- a/ertmain.py
+++ b/ertmain.py
@@ -1,104 +1,154 @@
-import requests
-from bs4 import BeautifulSoup
+import asyncio
+from playwright.async_api import async_playwright
 import csv
 from datetime import datetime
 import time
 import os
+import base64
+import requests
+import json
 
-# The URL of the PEI hospital wait times page
-URL = "https://www.princeedwardisland.ca/en/information/health-pei/emergency-department-wait-times"
+# The URLs of the PEI hospital wait times pages
+URLS = [
+    "https://www.princeedwardisland.ca/en/feature/emergency-department-wait-times-queen-elizabeth-hospital-qeh#/service/ERWaitTimes_QEH/ERWaitTimes_QEH",
+    "https://www.princeedwardisland.ca/en/feature/emergency-department-wait-times-prince-county-hospital-pch#/service/ERWaitTimes_PCH/ERWaitTimes_PCH",
+    "https://www.princeedwardisland.ca/en/feature/emergency-department-wait-times-kings-county-memorial-hospital-kcmh#/service/ERWaitTimes_KCMH/ERWaitTimes_KCMH",
+    "https://www.princeedwardisland.ca/en/feature/emergency-department-wait-times-western-hospital#/service/ERWaitTimes_WH/ERWaitTimes_WH"
+]
 
 # The name of the file where we'll save the data
 CSV_FILE = "hospital_wait_times.csv"
+LLAVA_API_URL = "http://localhost:11434/api/generate" # Default Ollama API URL
 
-def scrape_wait_times():
+async def capture_screenshot(url, screenshot_path):
     """
-    Scrapes the hospital wait times from the Health PEI website
-    and returns a list of dictionaries, one for each hospital.
+    Navigates to a URL and captures a screenshot.
     """
-    print("Fetching new wait times...")
+    async with async_playwright() as p:
+        browser = await p.chromium.launch()
+        page = await browser.new_page()
+        try:
+            print(f"Navigating to {url}...")
+            await page.goto(url, wait_until="networkidle", timeout=60000)
+            await page.screenshot(path=screenshot_path)
+            print(f"Screenshot saved to {screenshot_path}")
+            return screenshot_path
+        except Exception as e:
+            print(f"Error capturing screenshot from {url}: {e}")
+            return None
+        finally:
+            await browser.close()
+
+def encode_image(image_path):
+    """
+    Encodes an image file to base64.
+    """
+    with open(image_path, "rb") as image_file:
+        return base64.b64encode(image_file.read()).decode('utf-8')
+
+def analyze_image_with_llava(image_path):
+    """
+    Sends a screenshot to the Llava server for analysis.
+    """
+    print(f"Analyzing {image_path} with Llava...")
+    base64_image = encode_image(image_path)
+
+    payload = {
+        "model": "llava",
+        "prompt": "Analyze the attached screenshot of a hospital wait times website. Extract the name of the hospital and all wait time categories with their corresponding patient counts and wait times. Return the data as a clean, machine-readable JSON object. The JSON should have keys like 'hospital_name', 'patients_in_waiting_room', 'urgent_patients', 'urgent_wait_time', etc.",
+        "images": [base64_image]
+    }
+
     try:
-        # Get the webpage content
-        response = requests.get(URL)
-        response.raise_for_status() # This will raise an error for bad responses (4xx or 5xx)
-
-        # Parse the HTML with BeautifulSoup
-        soup = BeautifulSoup(response.text, 'html.parser')
-
-        # Find all the sections that contain hospital wait time info
-        # The site structure uses 'views-row' for each hospital block
-        hospital_blocks = soup.find_all('div', class_='views-row')
-        
-        scraped_data = []
-        
-        # Get the current time for the timestamp
-        timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-
-        for block in hospital_blocks:
-            # Find the hospital name (it's in an h3 tag)
-            hospital_name_tag = block.find('h3')
-            hospital_name = hospital_name_tag.get_text(strip=True) if hospital_name_tag else "N/A"
-            
-            # Find the wait time (it's in a div with a specific class)
-            wait_time_tag = block.find('div', class_='views-field-field-er-wait-times')
-            if wait_time_tag:
-                wait_time_text = wait_time_tag.get_text(strip=True)
-                # Remove the "Wait Time:" prefix for cleaner data
-                wait_time = wait_time_text.replace("Wait Time:", "").strip()
-            else:
-                wait_time = "N/A"
-            
-            # Add the collected data to our list
-            scraped_data.append({
-                "Timestamp": timestamp,
-                "Hospital": hospital_name,
-                "WaitTime": wait_time
-            })
-            
-        print(f"Successfully scraped {len(scraped_data)} entries.")
-        return scraped_data
-
-    except requests.exceptions.RequestException as e:
-        print(f"Error fetching the URL: {e}")
+        response = requests.post(LLAVA_API_URL, json=payload)
+        response.raise_for_status()
+        # The response from ollama is a stream of json objects, we need to parse the last one
+        lines = response.text.strip().split('\n')
+        last_line = lines[-1]
+        json_data_str = json.loads(last_line).get('response')
+        # Clean up the response from Llava
+        clean_json_str = json_data_str.strip().replace("```json", "").replace("```", "")
+        return json.loads(clean_json_str)
+    except (requests.exceptions.RequestException, json.JSONDecodeError) as e:
+        print(f"Error processing Llava response: {e}")
         return None
 
 def save_to_csv(data):
     """
-    Saves the scraped data to a CSV file.
+    Saves the parsed data to a CSV file.
     Creates the file and writes the header if it doesn't exist.
     """
-    # Check if the file already exists to decide whether to write the header
     file_exists = os.path.isfile(CSV_FILE)
     
+    # Define the column names for the CSV file
+    fieldnames = [
+        "Timestamp",
+        "HospitalName",
+        "DataUpdated",
+        "Category",
+        "Patients",
+        "WaitTime",
+        "PatientsBeingTreated",
+        "TotalPatientsInED"
+    ]
+
+    # Prepare the rows to be written to the CSV
+    rows_to_write = []
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+    hospital_name = data.get("hospital_name")
+    data_updated = data.get("data_updated")
+    additional_stats = data.get("additional_stats", {})
+    patients_being_treated = additional_stats.get("patients_being_treated")
+    total_patients_in_ed = additional_stats.get("total_patients_in_ed")
+
+    for entry in data.get("wait_times", []):
+        rows_to_write.append({
+            "Timestamp": timestamp,
+            "HospitalName": hospital_name,
+            "DataUpdated": data_updated,
+            "Category": entry.get("category"),
+            "Patients": entry.get("patients"),
+            "WaitTime": entry.get("wait_time"),
+            "PatientsBeingTreated": patients_being_treated,
+            "TotalPatientsInED": total_patients_in_ed
+        })
+
     try:
-        # Open the file in 'append' mode
         with open(CSV_FILE, mode='a', newline='', encoding='utf-8') as file:
-            # Define the column names
-            fieldnames = ["Timestamp", "Hospital", "WaitTime"]
             writer = csv.DictWriter(file, fieldnames=fieldnames)
-            
-            # If the file is new, write the header row
             if not file_exists:
                 writer.writeheader()
-            
-            # Write the data rows
-            writer.writerows(data)
-            
+            writer.writerows(rows_to_write)
         print(f"Data successfully saved to {CSV_FILE}")
-        
     except IOError as e:
         print(f"Error writing to file: {e}")
 
 
-if __name__ == "__main__":
+async def main():
+    """
+    Main function to orchestrate the scraping process.
+    """
     while True:
-        # 1. Scrape the data
-        data_to_save = scrape_wait_times()
-        
-        # 2. If data was scraped successfully, save it
-        if data_to_save:
-            save_to_csv(data_to_save)
+        for url in URLS:
+            screenshot_path = f"screenshot_{URLS.index(url)}.png"
+            screenshot_path = await capture_screenshot(url, screenshot_path)
             
-        # 3. Wait for an hour (3600 seconds) before running again
+            if screenshot_path:
+                # Analyze the screenshot with Llava
+                wait_time_data = analyze_image_with_llava(screenshot_path)
+
+                if wait_time_data:
+                    # Save the data to the CSV file
+                    save_to_csv(wait_time_data)
+
+                # Clean up the screenshot file
+                if os.path.exists(screenshot_path):
+                    os.remove(screenshot_path)
+
+        # Wait for an hour (3600 seconds) before running again
         print("Waiting for 1 hour before next scrape...")
         time.sleep(3600)
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 requests
 beautifulsoup4
+playwright


### PR DESCRIPTION
This commit refactors the project to use a multimodal AI approach for extracting emergency room wait times. The previous HTML scraping logic has been replaced with a new workflow that uses Playwright to capture screenshots of the hospital wait time pages and a local Llava model to extract structured data from the images.

The main script `ertmain.py` has been updated to:
- Use Playwright to navigate to the hardcoded URLs and take screenshots.
- Send the screenshots to a local Llava server for analysis.
- Parse the JSON response from Llava.
- Save the extracted data to `hospital_wait_times.csv` in a denormalized format.

The `README.md` has been updated to reflect the new methodology, including instructions for setting up and running a local Llava server with Ollama.

The `requirements.txt` file has been updated to include `playwright`.